### PR TITLE
Update the dependencies in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,23 +34,17 @@
     "Gruntfile.js"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.11.0",
+    "polymer": "Polymer/polymer#1.9 - 2",
     "Palindrom": "Palindrom/Palindrom#^v5.0.0"
   },
   "devDependencies": {
-    "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
-    "iron-image": "polymerelements/iron-image#^1.0.0",
-    "paper-styles": "polymerelements/paper-styles#^1.0.0",
-    "test-fixture": "polymerelements/test-fixture#^1.0.0",
-    "web-component-tester": "^4.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+    "iron-component-page": "PolymerElements/iron-component-page#1 - 2",
+    "paper-styles": "polymerelements/paper-styles#1 - 2",
+    "test-fixture": "PolymerElements/test-fixture#^3.0.0",
+    "web-component-tester": "^6.0.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
     "jasmine-core": "jasmine#^2.4.1",
     "jasmine-ajax": "^3.2.0",
-    "starcounter-include": "Starcounter/starcounter-include#master",
-    "fast-json-patch": "Starcounter-jack/JSON-Patch#^2.0.0"
-  },
-  "resolutions": {
-    "chai": "^3.2.0",
-    "imported-template": ">=1.3.0"
+    "starcounter-include": "Starcounter/starcounter-include#master"
   }
 }


### PR DESCRIPTION
because WCv0 and P1 dependency breaks Test with Apps build on TeamCity.

With these changes, the `Test With Apps (Palindrom-client)` build passes: https://teamcity.starcounter.org/viewLog.html?buildId=47897&tab=buildResultsDiv&buildTypeId=Apps_WebPlatform_PalindromClient_TestWithApps