### PR TITLE
WIP: Reuse existing instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ remote-url / remoteUrl | `String` | `window.location` | The remote's URL
 remoteVersionPath | `JSONPointer` | `/_ver#s` | remote version path, set it to falsy to disable Double Versioned JSON Patch communication
 useWebSocket | `Boolean` | `true` | Set to false to disable WebSocket (use HTTP)
 fatalErrorReloadAfterS | `Number` | 5      | Timeout in seconds until the page refreshes upon connection errors
+isUsingOwnInstanceOfPalindrom | `Boolean` | `true` when `palindrom-client` has created and is using its own Palindrom instance, as opposed to connecting to an existing one.
 ## Events
 
 Name                       | Description

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Or [download as ZIP](https://github.com/Palindrom/palindrom-client/archive/maste
 2. Import Custom Element:
 
     ```html
+    <!-- include Palindrom with dependencies -->
+    <script src="bower_components/Palindrom/dist/palindrom-dom.min.js"></script>
     <link rel="import" href="bower_components/palindrom-client/palindrom-client.html">
     ```
 

--- a/bower.json
+++ b/bower.json
@@ -34,10 +34,10 @@
     "Gruntfile.js"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#1.9 - 2",
     "Palindrom": "Palindrom/Palindrom#^v5.0.0"
   },
   "devDependencies": {
+    "polymer": "Polymer/polymer#1.9 - 2",
     "iron-component-page": "PolymerElements/iron-component-page#1 - 2",
     "paper-styles": "polymerelements/paper-styles#1 - 2",
     "test-fixture": "PolymerElements/test-fixture#^3.0.0",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "palindrom-polymer-client",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Three-way data binding server - JS - HTML kept in flawless sync with JSON Patch, WebSockets/HTTP.",
   "private": true,
   "authors": [

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,6 +6,7 @@
     <title>palindrom-polymer-client</title>
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../Palindrom/dist/palindrom-dom.min.js"></script>
     <link rel="import" href="../palindrom-client.html">
     <script src="../../fast-json-patch/dist/fast-json-patch.min.js"></script>
 

--- a/demo/mockServer.js
+++ b/demo/mockServer.js
@@ -3,7 +3,7 @@
       clientVersionNumber = 0,
       enableServerReplies = true;
 
-  WebSocket = function FakeWebSocket(){
+  WebSocket = function FakeWebSocket() {
     this.readyState = 1;
   };
   var full = {

--- a/palindrom-client.html
+++ b/palindrom-client.html
@@ -186,7 +186,13 @@ All the changes from server are also received and propagated to your HTML.
                     listenTo = typeof listenTo == "string" ? document.getElementById(listenTo) : listenTo;
                 }
                 let palindrom = PalindromDOM.instances && PalindromDOM.instances.get(this.remoteUrl);
-                if(!palindrom){
+                if(!palindrom) {
+                    /**
+                     * To tell whether we connected to an existing instance,
+                     * or created our own. This is useful for detachement, we don't want
+                     * to destroy Palindrom instances that we don't own 
+                     * */
+                    this.isUsingOwnInstanceOfPalindrom = true;
                     this.palindrom = palindrom = new PalindromDOM({
                         remoteUrl: this.remoteUrl,
                         pingIntervalS,
@@ -223,6 +229,7 @@ All the changes from server are also received and propagated to your HTML.
                     }
                     PalindromDOM.instances.set(this.remoteUrl, palindrom);
                 } else {
+                    this.isUsingOwnInstanceOfPalindrom = false;
                     // with already established connection we cannot change listenTo parameter
 
                     this.palindrom = palindrom;
@@ -253,11 +260,12 @@ All the changes from server are also received and propagated to your HTML.
                 this.morphUrl = palindrom.morphUrl.bind(palindrom)
             }
             disconnectedCallback(){
-                // TODO: add test for detaching, if we keep anything here after the refactoring
-                this.palindrom.unlisten();
-                // hacky way to stop Palindrom connection
-                this.palindrom.useWebSocket = false;
-                PalindromDOM.instances.delete(this.remoteUrl);
+                if(this.isUsingOwnInstanceOfPalindrom) {
+                    this.palindrom.unlisten();
+                    // hacky way to stop Palindrom connection
+                    this.palindrom.useWebSocket = false;
+                    PalindromDOM.instances.delete(this.remoteUrl);
+                }
             }
             bindTo(element) {
                 // use node id or node itself;

--- a/palindrom-client.html
+++ b/palindrom-client.html
@@ -218,7 +218,11 @@ All the changes from server are also received and propagated to your HTML.
                 this.network = this.palindrom.network;
                 this.morphUrl = this.palindrom.morphUrl.bind(this.palindrom);
             }
-
+            disconnectedCallback(){
+                this.palindrom.unlisten();
+                // hacky way to stop Palindrom connection
+                this.palindrom.useWebSocket = false;
+            }
             bindTo(element) {
                 // use node id or node itself;
                 element = typeof element == "string" ? document.getElementById(element) : element;

--- a/palindrom-client.html
+++ b/palindrom-client.html
@@ -104,7 +104,7 @@ All the changes from server are also received and propagated to your HTML.
         </div>
     </div>
 </template>
-<script>      
+<script>
 
 
     (function() {
@@ -126,15 +126,15 @@ All the changes from server are also received and propagated to your HTML.
         const defaultAttributes = ['remote-url', 'use-web-socket', 'debug', 'local-version-path', 'remote-version-path', 'ot', 'purity', 'listen-to', 'ping-interval-s', 'purity', 'fatal-error-reload-after-s', 'path'];
 
         class PalindromClient extends HTMLElement {
-            
+
             constructor() {
                 super();
-                
+
                 // assign default properties
-                Object.assign(this, defaultProps);                
+                Object.assign(this, defaultProps);
 
                 // Creates the shadow root
-                const shadowRoot = this.attachShadow({ mode: 'open' });                
+                const shadowRoot = this.attachShadow({ mode: 'open' });
                 const clone = document.importNode(template.content, true);
                 shadowRoot.appendChild(clone);
 
@@ -147,7 +147,7 @@ All the changes from server are also received and propagated to your HTML.
                 // attach event handlers
                 for(const el of shadowRoot.querySelectorAll('[on-tap]')) {
                     el.addEventListener('click', this[el.getAttribute('on-tap')].bind(this));
-                }                
+                }
             }
 
             reconnectNow() {
@@ -169,7 +169,7 @@ All the changes from server are also received and propagated to your HTML.
              *
              */
             connectedCallback() {
-                
+
                 // assign default attributes
                 for (const attrib of this.attributes) {
                     if (defaultAttributes.includes(attrib.name)) {
@@ -185,43 +185,79 @@ All the changes from server are also received and propagated to your HTML.
                 if (listenTo) {
                     listenTo = typeof listenTo == "string" ? document.getElementById(listenTo) : listenTo;
                 }
+                let palindrom = PalindromDOM.instances && PalindromDOM.instances.get(this.remoteUrl);
+                if(!palindrom){
+                    this.palindrom = palindrom = new PalindromDOM({
+                        remoteUrl: this.remoteUrl,
+                        pingIntervalS,
+                        useWebSocket: this.useWebSocket,
+                        debug: this.debug,
+                        ot: this.ot,
+                        purity: this.purity,
+                        localVersionPath: this.localVersionPath,
+                        remoteVersionPath: this.remoteVersionPath,
 
-                this.palindrom = new PalindromDOM({
-                    remoteUrl: this.remoteUrl,
-                    pingIntervalS,
-                    listenTo,
-                    useWebSocket: this.useWebSocket,
-                    debug: this.debug,
-                    onLocalChange: this.onLocalChange.bind(this),
-                    onRemoteChange: this.onPatchApplied.bind(this),
-                    onPatchReceived: this.onPatchReceived.bind(this),
-                    onIncomingPatchValidationError: this.onGenericError.bind(this),
-                    onOutgoingPatchValidationError: this.onGenericError.bind(this),
-                    onError: this.onGenericError.bind(this),
-                    onPatchSent: this.onPatchSent.bind(this),
-                    onSocketStateChanged: this.onSocketStateChanged.bind(this),
-                    onConnectionError: this.onConnectionError.bind(this),
-                    onReconnectionCountdown: this.onReconnectionCountdown.bind(this),
-                    onReconnectionEnd: this.onReconnectionEnd.bind(this),
-                    localVersionPath: this.localVersionPath,
-                    remoteVersionPath: this.remoteVersionPath,
-                    ot: this.ot,
-                    purity: this.purity,
-                    onStateReset: obj => {
+                        listenTo,
+
+                        onLocalChange: this.onLocalChange.bind(this),
+                        onRemoteChange: this.onPatchApplied.bind(this),
+                        onPatchReceived: this.onPatchReceived.bind(this),
+                        onIncomingPatchValidationError: this.onGenericError.bind(this),
+                        onOutgoingPatchValidationError: this.onGenericError.bind(this),
+                        onError: this.onGenericError.bind(this),
+                        onPatchSent: this.onPatchSent.bind(this),
+                        onSocketStateChanged: this.onSocketStateChanged.bind(this),
+                        onConnectionError: this.onConnectionError.bind(this),
+                        onReconnectionCountdown: this.onReconnectionCountdown.bind(this),
+                        onReconnectionEnd: this.onReconnectionEnd.bind(this),
+                        onStateReset: obj => {
+                            this.obj = obj;
+                            if (whereToBind) {
+                                this.bindTo(whereToBind);
+                            }
+                            this.onPatchApplied([{ op: 'replace', path: '', value: obj }], [{ removed: this.obj }])
+                        }
+                    });
+                    if(!PalindromDOM.instances){
+                        PalindromDOM.instances = new Map();
+                    }
+                    PalindromDOM.instances.set(this.remoteUrl, palindrom);
+                } else {
+                    // with already established connection we cannot change listenTo parameter
+
+                    this.palindrom = palindrom;
+                    palindrom.onLocalChange =  this.onLocalChange.bind(this);
+                    palindrom.onRemoteChange =  this.onPatchApplied.bind(this);
+                    palindrom.onPatchReceived =  this.onPatchReceived.bind(this);
+                    palindrom.onIncomingPatchValidationError =  this.onGenericError.bind(this);
+                    palindrom.onOutgoingPatchValidationError =  this.onGenericError.bind(this);
+                    palindrom.onError =  this.onGenericError.bind(this);
+                    palindrom.onPatchSent =  this.onPatchSent.bind(this);
+                    palindrom.onSocketStateChanged =  this.onSocketStateChanged.bind(this);
+                    palindrom.onConnectionError =  this.onConnectionError.bind(this);
+                    palindrom.onReconnectionCountdown =  this.onReconnectionCountdown.bind(this);
+                    palindrom.onReconnectionEnd =  this.onReconnectionEnd.bind(this);
+                    palindrom.onStateReset =  obj => {
                         this.obj = obj;
                         if (whereToBind) {
                             this.bindTo(whereToBind);
                         }
                         this.onPatchApplied([{ op: 'replace', path: '', value: obj }], [{ removed: this.obj }])
                     }
-                });
-                this.network = this.palindrom.network;
-                this.morphUrl = this.palindrom.morphUrl.bind(this.palindrom);
+                    // if already established (re-)set state
+                    if(palindrom.obj){
+                        palindrom.onStateReset(palindrom.obj);
+                    }
+                }
+                this.network = palindrom.network;
+                this.morphUrl = palindrom.morphUrl.bind(palindrom)
             }
             disconnectedCallback(){
+                // TODO: add test for detaching, if we keep anything here after the refactoring
                 this.palindrom.unlisten();
                 // hacky way to stop Palindrom connection
                 this.palindrom.useWebSocket = false;
+                PalindromDOM.instances.delete(this.remoteUrl);
             }
             bindTo(element) {
                 // use node id or node itself;
@@ -274,7 +310,7 @@ All the changes from server are also received and propagated to your HTML.
                     reason
                 });
             }
-            
+
             updateReconnectionSeconds(seconds) {
                 for(const span of this.reconnectionSecondsSpans) {
                     span.textContent = seconds;
@@ -289,7 +325,7 @@ All the changes from server are also received and propagated to your HTML.
 
                 if (!eventDetail.handled) {
                     console.error(palindromConnectionError);
-                    
+
                     this.errorPane.removeAttribute('hidden');
 
                     this.reloadingInMessage.removeAttribute('hidden');
@@ -300,7 +336,7 @@ All the changes from server are also received and propagated to your HTML.
 
                     this.reloadingInterval = setInterval(() => {
                         if(!this.reloadingInterval) {
-                            
+
                             // to make sure to skip even before interval clears
                             return;
                         }
@@ -312,7 +348,7 @@ All the changes from server are also received and propagated to your HTML.
                     }, 1000);
                 }
                 }
-            
+
 
             onGenericError(error) {
                 this.showGenericError = true;
@@ -388,7 +424,7 @@ All the changes from server are also received and propagated to your HTML.
                         const lastSeparator = operation.path.lastIndexOf('/');
                         let name = operation.path.substr(lastSeparator + 1);
                         const parentsPolymerPath = polymerPathPrefix + translateJSONPointerToPolymerPath(operation.path.substring(0, lastSeparator));
-    
+
                         const parent = templateDomBind.get(parentsPolymerPath);
                         if (Array.isArray(parent) && (name === '-' || isNormalInteger(name))) {
                             switch (operation.op) {

--- a/palindrom-client.html
+++ b/palindrom-client.html
@@ -1,8 +1,5 @@
 <!-- palindrom-polymer-client version: 5.0.0 | MIT License -->
 
-<!-- include Palindrom with dependencies -->
-<script src="../Palindrom/dist/palindrom-dom.js"></script>
-
 <!--
 `palindrom-client` element binds [Palindrom](https://github.com/Palindrom/Palindrom) with [Polymer's template binding](https://www.polymer-project.org/2.0/docs/devguide/templates.html).
 That keeps your Polymer app, or just `dom-bind` template in sync with any server-side

--- a/palindrom-client.html
+++ b/palindrom-client.html
@@ -1,4 +1,4 @@
-<!-- palindrom-polymer-client version: 5.0.0 | MIT License -->
+<!-- palindrom-polymer-client version: 6.0.0 | MIT License -->
 
 <!--
 `palindrom-client` element binds [Palindrom](https://github.com/Palindrom/Palindrom) with [Polymer's template binding](https://www.polymer-project.org/2.0/docs/devguide/templates.html).

--- a/test/d-b-n_smoke/arrays.html
+++ b/test/d-b-n_smoke/arrays.html
@@ -8,6 +8,13 @@
     <title>Test suite for array operations</title>
     <!-- Importing Web Component's Polyfill -->
     <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <!-- mock server responses -->
+    <script src="../../../sinonjs/sinon.js"></script>
+    <script src="../../demo/mockServer.js"></script>
+    <script src="../../../fast-json-patch/dist/fast-json-patch.min.js"></script>
+
+    
     <link rel="import" href="../shared/helpers.html">
 
     <link rel="import" href="../../../polymer/polymer.html">

--- a/test/d-b-n_smoke/arrays.html
+++ b/test/d-b-n_smoke/arrays.html
@@ -15,6 +15,7 @@
     <script src="../../../web-component-tester/browser.js"></script>
 
     <!-- Step 1: import the element to test -->
+    <script src="../../../Palindrom/dist/palindrom-dom.min.js"></script>
     <link rel="import" href="../../palindrom-client.html">
 </head>
 

--- a/test/d-b-n_smoke/attachment.html
+++ b/test/d-b-n_smoke/attachment.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <title>Test suite for deep array operations</title>
+    <!-- Importing Web Component's Polyfill -->
+    <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <!-- mock server responses -->
+    <script src="../../../sinonjs/sinon.js"></script>
+    <script src="../../demo/mockServer.js"></script>
+    <script src="../../../fast-json-patch/dist/fast-json-patch.min.js"></script>
+
+    <link rel="import" href="../shared/helpers.html">
+
+    <script src="../../../web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../../../polymer/polymer.html">
+
+    <!-- Step 1: import the element to test -->
+    <script src="../../../Palindrom/dist/palindrom-dom.min.js"></script>
+
+    <link rel="import" href="../../palindrom-client.html">
+</head>
+
+<body>
+    <test-fixture id="my-fixture">
+        <template>
+            <div><palindrom-client remote-url="/palindrom" ref="deep_array" ping-interval-s="0"></palindrom-client></div>
+        </template>
+    </test-fixture>
+
+    <test-fixture id="my-fixture-existent-palindrom-dom">
+        <template>
+            <div><palindrom-client remote-url="/palindrom-exists" ref="deep_array" ping-interval-s="0"></palindrom-client></div>
+        </template>
+    </test-fixture>
+
+    <script>
+        describe('Attachment - non-existent PalindromDOM', function () {
+            var container;
+            it('Should create an instance of PalindromDOM once attached', function (done) {
+                expect(PalindromDOM.instances).to.equal(undefined);
+                container = fixture('my-fixture');
+                setTimeout(() => {
+                    expect(PalindromDOM.instances).to.not.equal(undefined);
+                    expect(PalindromDOM.instances.size).to.equal(1);
+                    done();
+                }, 10);
+            });
+
+            it('Should destroy the instance of PalindromDOM once deattached and remove it from the instances map', function (done) {
+                expect(PalindromDOM.instances.size).to.equal(0);
+                container = fixture('my-fixture');
+                setTimeout(() => {
+                    expect(PalindromDOM.instances).to.not.equal(undefined);
+                    expect(PalindromDOM.instances.size).to.equal(1);                   
+
+                    // now detach it
+                    container.querySelector('palindrom-client').remove();
+                    expect(PalindromDOM.instances.size).to.equal(0);
+                    done();
+                }, 10);
+            });
+        });
+
+        describe('Attachment - existent PalindromDOM', function () {  
+            var container, instance;
+
+            beforeEach(function() {
+                instance = new PalindromDOM({remoteUrl: '/palindrom-exists'});
+                PalindromDOM.instances.set('/palindrom-exists', instance);
+            });
+
+            after(function() {
+                delete PalindromDOM.instances;
+            });
+
+            it('Should use existing Palindrom instance', function (done) {
+                container = fixture('my-fixture-existent-palindrom-dom');
+                setTimeout(() => {
+                    const palindromClient = container.querySelector('palindrom-client');
+                    assert(palindromClient.palindrom === instance, "palindromClient should use the existing PalindromDOM instance");
+                    done();
+                }, 10);
+            });
+
+            it('Should NOT destroy the instance of PalindromDOM once deattached (because it does not own it)', function (done) {
+                // there is a ready PalindromDOM instance
+                expect(PalindromDOM.instances.size).to.equal(1);
+                // this must use that ready instance
+                container = fixture('my-fixture-existent-palindrom-dom');
+
+                // make sure it didn't create a new one
+                expect(PalindromDOM.instances.size).to.equal(1);
+
+                setTimeout(() => {     
+                    // now detach it
+                    container.querySelector('palindrom-client').remove();
+                    
+                    // instance should not be removed
+                    expect(PalindromDOM.instances.size).to.equal(1);
+                    done();
+                }, 10);
+            });
+        });
+    </script>
+
+</body>
+
+</html>

--- a/test/d-b-n_smoke/consecutive-notifcations.html
+++ b/test/d-b-n_smoke/consecutive-notifcations.html
@@ -17,6 +17,7 @@
     <script src="../../../web-component-tester/browser.js"></script>
 
     <!-- Step 1: import the element to test -->
+    <script src="../../../Palindrom/dist/palindrom-dom.min.js"></script>
     <link rel="import" href="../../palindrom-client.html">
 </head>
 

--- a/test/d-b-n_smoke/consecutive-notifcations.html
+++ b/test/d-b-n_smoke/consecutive-notifcations.html
@@ -13,6 +13,10 @@
 
     <link rel="import" href="../shared/helpers.html">
 
+    <!-- mock server responses -->
+    <script src="../../../sinonjs/sinon.js"></script>
+    <script src="../../demo/mockServer.js"></script>
+    <script src="../../../fast-json-patch/dist/fast-json-patch.min.js"></script>
 
     <script src="../../../web-component-tester/browser.js"></script>
 

--- a/test/d-b-n_smoke/deep.html
+++ b/test/d-b-n_smoke/deep.html
@@ -7,6 +7,12 @@
 
     <!-- Importing Web Component's Polyfill -->
     <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <!-- mock server responses -->
+    <script src="../../../sinonjs/sinon.js"></script>
+    <script src="../../demo/mockServer.js"></script>
+    <script src="../../../fast-json-patch/dist/fast-json-patch.min.js"></script>
+
     <link rel="import" href="../shared/helpers.html">
     <script src="../../../web-component-tester/browser.js"></script>
 

--- a/test/d-b-n_smoke/deep.html
+++ b/test/d-b-n_smoke/deep.html
@@ -13,6 +13,7 @@
     <link rel="import" href="../../../polymer/polymer.html">
 
     <!-- Step 1: import the element to test -->
+    <script src="../../../Palindrom/dist/palindrom-dom.min.js"></script>
     <link rel="import" href="../../palindrom-client.html">
 </head>
 

--- a/test/d-b-n_smoke/deep_array_0.html
+++ b/test/d-b-n_smoke/deep_array_0.html
@@ -15,6 +15,7 @@
     <link rel="import" href="../../../polymer/polymer.html">
 
     <!-- Step 1: import the element to test -->
+    <script src="../../../Palindrom/dist/palindrom-dom.min.js"></script>
     <link rel="import" href="../../palindrom-client.html">
 </head>
 

--- a/test/d-b-n_smoke/deep_array_0.html
+++ b/test/d-b-n_smoke/deep_array_0.html
@@ -8,6 +8,13 @@
     <title>Test suite for deep array operations</title>
     <!-- Importing Web Component's Polyfill -->
     <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <!-- mock server responses -->
+    <script src="../../../sinonjs/sinon.js"></script>
+    <script src="../../demo/mockServer.js"></script>
+    <script src="../../../fast-json-patch/dist/fast-json-patch.min.js"></script>
+
+
     <link rel="import" href="../shared/helpers.html">
 
     <script src="../../../web-component-tester/browser.js"></script>

--- a/test/d-b-n_smoke/reconnection.html
+++ b/test/d-b-n_smoke/reconnection.html
@@ -8,6 +8,12 @@
     <title>Test suite for reconnection</title>
     <!-- Importing Web Component's Polyfill -->
     <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <!-- mock server responses -->
+    <script src="../../../sinonjs/sinon.js"></script>
+    <script src="../../demo/mockServer.js"></script>
+    <script src="../../../fast-json-patch/dist/fast-json-patch.min.js"></script>
+
     <link rel="import" href="../shared/helpers.html">
 
     <script src="../../../web-component-tester/browser.js"></script>

--- a/test/d-b-n_smoke/reconnection.html
+++ b/test/d-b-n_smoke/reconnection.html
@@ -15,6 +15,7 @@
     <link rel="import" href="../../../polymer/polymer.html">
 
     <!-- Step 1: import the element to test -->
+    <script src="../../../Palindrom/dist/palindrom-dom.min.js"></script>
     <link rel="import" href="../../palindrom-client.html">
 </head>
 

--- a/test/d-b-n_smoke/simple.html
+++ b/test/d-b-n_smoke/simple.html
@@ -7,13 +7,21 @@
     <!-- Importing Web Component's Polyfill -->
     <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 
+    <!-- mock server responses -->
+    <script src="../../../sinonjs/sinon.js"></script>
+    <script src="../../demo/mockServer.js"></script>
+    <script src="../../../fast-json-patch/dist/fast-json-patch.min.js"></script>
+
     <link rel="import" href="../../../polymer/polymer.html">
 
     <link rel="import" href="../shared/helpers.html">
+
     <script src="../../../web-component-tester/browser.js"></script>
+    
 
     <!-- Step 1: import the element to test -->
     <script src="../../../Palindrom/dist/palindrom-dom.min.js"></script>
+
     <link rel="import" href="../../palindrom-client.html">
 </head>
 <body>

--- a/test/d-b-n_smoke/simple.html
+++ b/test/d-b-n_smoke/simple.html
@@ -13,6 +13,7 @@
     <script src="../../../web-component-tester/browser.js"></script>
 
     <!-- Step 1: import the element to test -->
+    <script src="../../../Palindrom/dist/palindrom-dom.min.js"></script>
     <link rel="import" href="../../palindrom-client.html">
 </head>
 <body>

--- a/test/index.html
+++ b/test/index.html
@@ -11,6 +11,7 @@
         // 'd-b-n_smoke/simpleAsyncModel.html',
         'd-b-n_smoke/deep.html',
         'd-b-n_smoke/arrays.html',
+        'd-b-n_smoke/attachment.html',
         'd-b-n_smoke/deep_array_0.html',
         'd-b-n_smoke/reconnection.html',
         'd-b-n_smoke/consecutive-notifcations.html'

--- a/test/shared/helpers.html
+++ b/test/shared/helpers.html
@@ -1,8 +1,3 @@
-<!-- mock server responses -->
-<script src="../../../sinonjs/sinon.js"></script>
-<script src="../../demo/mockServer.js"></script>
-<script src="../../../fast-json-patch/dist/fast-json-patch.min.js"></script>
-
 <script>
     window.operationObject = function (op, path, value) {
         var o = {


### PR DESCRIPTION
:warning: do not merge yet, tests are failing in firefox


- Remove Palindrom script from the HTML import, so it could be loaded before, without duplicate requests
- Implement detached callback, to stop listening and stop connection in hacky way once element is detached from DOM
- Let the element bind to existing connection, if there is one created elsewhere for the same remote

required for Starcounter/RebelsLounge#248