### PR TITLE
For 100+ operation patches, replace the whole object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - npm install bower
   - 'export PATH=$PWD/node_modules/.bin:$PATH'
   - bower install
-node_js: 6
+node_js: 8
 addons:
   apt:
     sources:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ ref   | `String` or `HTMLElement` | element itself | To which element (polymer e
 debug | `Boolean` | `false` | Set to `true` to enable debugging mode
 listenTo | `String` | `document.body` | DOM node to listen to (see PalindromDOM listenTo attribute)
 localVersionPath | `JSONPointer` | `/_ver#c$` | local version path, set to falsy do disable Versioned JSON Patch communication
+mergedNotificationsThreshold | `Number` | 100 | The minimum number of operations in the patch where `palindrom-client` stops applying updates individually and resets the whole view model for better performance. This limits the number of DOM interactions for bigger patches.
 obj | `Object` | `{}` | **notifies** Object that will be synced
 ot | `Boolean` | `true` | `false` to disable OT
 path | `String` | `/` | Path to given obj

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ ref   | `String` or `HTMLElement` | element itself | To which element (polymer e
 debug | `Boolean` | `false` | Set to `true` to enable debugging mode
 listenTo | `String` | `document.body` | DOM node to listen to (see PalindromDOM listenTo attribute)
 localVersionPath | `JSONPointer` | `/_ver#c$` | local version path, set to falsy do disable Versioned JSON Patch communication
-mergedNotificationsThreshold | `Number` | 100 | The minimum number of operations in the patch where `palindrom-client` stops applying updates individually and resets the whole view model for better performance. This limits the number of DOM interactions for bigger patches.
+mergedNotificationsThreshold | `Number` | 100 | The minimum number of operations in the patch where `palindrom-client` stops applying updates individually and resets the whole state object for better performance. This limits the number of DOM interactions for bigger patches.
 obj | `Object` | `{}` | **notifies** Object that will be synced
 ot | `Boolean` | `true` | `false` to disable OT
 path | `String` | `/` | Path to given obj

--- a/palindrom-client.html
+++ b/palindrom-client.html
@@ -252,6 +252,9 @@ All the changes from server are also received and propagated to your HTML.
             notifyTemplateDomBind(tree, patchesAndResults, templateDomBind, polymerPathPrefix) {
                 let operation;
                 let polymerPath;
+                const splices = {};
+                const notifications = {};
+
                 for (let operationNo = 0, len = patchesAndResults.patches.length; operationNo < len; operationNo++) {
                     operation = patchesAndResults.patches[operationNo];
                     const result = patchesAndResults.results[operationNo];
@@ -273,6 +276,9 @@ All the changes from server are also received and propagated to your HTML.
 
                     polymerPath = polymerPathPrefix + translateJSONPointerToPolymerPath(operation.path);
 
+                    /**
+                    *  STEP 1: COLLECT THE UPDATES, UNIQ THEM BY PATH
+                    * */
                     if (operation.op === 'test') {
                         // we assume that jsonpatch covered it already
                     } else if (operation.op === 'move' || operation.op === 'copy') {
@@ -284,65 +290,82 @@ All the changes from server are also received and propagated to your HTML.
                         const parentsPolymerPath = polymerPathPrefix + translateJSONPointerToPolymerPath(operation.path.substring(0, lastSeparator));
 
                         const parent = templateDomBind.get(parentsPolymerPath);
+
                         if (Array.isArray(parent) && (name === '-' || isNormalInteger(name))) {
+                            if (!splices[parentsPolymerPath]) {
+                                splices[parentsPolymerPath] = [];
+                            }
                             switch (operation.op) {
                                 case 'add':
                                     // JSONPatch push
                                     if (name === '-') {
                                         name = result.index;
                                     }
-                                    templateDomBind.notifySplices(parentsPolymerPath,
-                                        [{
-                                            index: parseInt(name, 10),
-                                            removed: [],
-                                            addedCount: 1,
-                                            object: parent,
-                                            type: 'splice'
-                                        }]
-                                    );
+                                    splices[parentsPolymerPath].push({
+                                        index: parseInt(name, 10),
+                                        removed: [],
+                                        addedCount: 1,
+                                        object: parent,
+                                        type: 'splice'
+                                    })
                                     break;
                                 case 'replace':
-                                    templateDomBind.notifySplices(parentsPolymerPath,
-                                        [{
-                                            index: parseInt(name, 10),
-                                            removed: (result && [result.removed]) || [],
-                                            addedCount: 1,
-                                            object: parent,
-                                            type: 'splice'
-                                        }]
-                                    );
+                                    splices[parentsPolymerPath].push({
+                                        index: parseInt(name, 10),
+                                        removed: (result && [result.removed]) || [],
+                                        addedCount: 1,
+                                        object: parent,
+                                        type: 'splice'
+                                    });
                                     break;
                                 case 'remove':
-                                    templateDomBind.notifySplices(parentsPolymerPath,
-                                        [{
-                                            index: parseInt(name, 10),
-                                            removed: (result && [result.removed]) || [],
-                                            addedCount: 0,
-                                            object: parent,
-                                            type: 'splice'
-                                        }]
-                                    );
+                                    splices[parentsPolymerPath].push({
+                                        index: parseInt(name, 10),
+                                        removed: (result && [result.removed]) || [],
+                                        addedCount: 0,
+                                        object: parent,
+                                        type: 'splice'
+                                    });
                                     break;
                             }
                         } else {
                             switch (operation.op) {
-
                                 case 'add':
                                 case 'replace':
                                     if (typeof operation.value === 'object') {
-                                        templateDomBind.notifyPath(polymerPath);
+                                        notifications[polymerPath] = [];
                                     } else {
-                                        templateDomBind.notifyPath(polymerPath, operation.value, false);
+                                        notifications[polymerPath] = [operation.value, false];
                                     }
                                     break;
                                 case 'remove':
-                                    //console.warn('Polymer does not support unsetting properties https://github.com/Polymer/polymer/issues/2565');
-                                    //console.warn('remove is translated to JSON incompatible set to `undefined`, as there is no remove method in Polymer.')
-                                    templateDomBind.notifyPath(polymerPath, null, false);
-                                    templateDomBind.notifyPath(polymerPath, undefined, false);
+                                    notifications[polymerPath] = [null, false];
                                     break;
                             }
                         }
+                    }
+                }
+                /**
+                *  STEP 2: APPLY THE UPDATES
+                * */
+                const spliceEntries = Object.entries(splices);
+                const notificationEntries = Object.entries(notifications);
+                if (spliceEntries.length + notificationEntries.length > 100) {
+                    console.warn(`palindrom-client has noticed a huge patch of ${patchesAndResults.patches.length} operations, for better performance palindrom-client will replace the whole palindrom object instead of applying your updates individually`);
+                    // clone to prevent flash of content
+                    templateDomBind.set('model', JSON.parse(JSON.stringify(this.obj)));
+                    // Polymer 2 is sync
+                    if (Polymer.Element) {
+                        templateDomBind.set('model', this.obj);
+                    } else { // Polymer 1 is async
+                        setTimeout(() => templateDomBind.set('model', this.obj));
+                    }
+                } else {
+                    for (const [path, parameters] of spliceEntries) {
+                        templateDomBind.notifySplices(path, parameters);
+                    }
+                    for (const [path, parameters] of notificationEntries) {
+                        templateDomBind.notifyPath(path, ...parameters);
                     }
                 }
             }

--- a/palindrom-client.html
+++ b/palindrom-client.html
@@ -1,4 +1,4 @@
-<!-- palindrom-polymer-client version: 7.0.0 | MIT License -->
+<!-- palindrom-polymer-client version: 7.1.0 | MIT License -->
 
 <!--
 `palindrom-client` element binds [Palindrom](https://github.com/Palindrom/Palindrom) with [Polymer's template binding](https://www.polymer-project.org/2.0/docs/devguide/templates.html).

--- a/palindrom-client.html
+++ b/palindrom-client.html
@@ -4,24 +4,17 @@
 `palindrom-client` element binds [Palindrom](https://github.com/Palindrom/Palindrom) with [Polymer's template binding](https://www.polymer-project.org/2.0/docs/devguide/templates.html).
 That keeps your Polymer app, or just `dom-bind` template in sync with any server-side
 data-model using Palindrom & [JSON Patch](https://tools.ietf.org/html/rfc6902) flow.
-
 You get three-way data binding server - JS - HTML, kept in flawless sync.
-
     <palindrom-client
         obj="{{model}}"></palindrom-client>
-
-
 It establishes the Palindrom connection when attached. All the changes made
 in browser are sent to the server via WebSocket or HTTP, as
 [JSON Patch](https://tools.ietf.org/html/rfc6902)es.
 All the changes from server are also received and propagated to your HTML.
-
 -->
 <script src="../Palindrom/dist/palindrom-dom.min.js"></script>
 
 <script>
-
-
     (function () {
         const defaultProps = {
             "useWebSocket": true,
@@ -33,50 +26,50 @@ All the changes from server are also received and propagated to your HTML.
             "pingIntervalS": 60,
             "path": '/',
             "devToolsOpen": false,
-            "fatalErrorReloadAfterS": 5
+            "fatalErrorReloadAfterS": 5,
+            "mergedNotificationsThreshold": 100
         }
-        const defaultAttributes = ['remote-url', 'use-web-socket', 'debug', 'local-version-path', 'remote-version-path', 'ot', 'purity', 'listen-to', 'ping-interval-s', 'purity', 'fatal-error-reload-after-s', 'path'];
-
         class PalindromClient extends HTMLElement {
-
             constructor() {
                 super();
-
                 // assign default properties
                 Object.assign(this, defaultProps);
             }
-
+            static get observedAttributes() {
+                return ['merged-notifications-threshold', 'remote-url', 'use-web-socket', 'debug', 'local-version-path', 'remote-version-path', 'ot', 'purity', 'listen-to', 'ping-interval-s', 'purity', 'fatal-error-reload-after-s', 'path'];
+            }
             reconnectNow() {
                 this.palindrom.reconnectNow();
             }
-
             reload() {
                 window.location.reload();
             }
-
+            attributeChangedCallback(name, oldValue, value) {
+                this.copyAttribsToProps([{ name, value }]);
+            }
+            copyAttribsToProps(attribs) {
+                for (const attrib of attribs) {
+                    if (PalindromClient.observedAttributes.includes(attrib.name)) {
+                        const prop = kebebCaseToCamelCase(attrib.name);
+                        this[prop] = attrib.value;
+                    }
+                };
+            }
             cancelReloading() {
                 clearInterval(this.reloadingInterval);
                 delete this.reloadingInterval;
             }
-
             /**
              * assigns an instance of Palindrom according to given params, attaches it to .palindrom property
              *
              */
             connectedCallback() {
-
-                // assign default attributes
-                for (const attrib of this.attributes) {
-                    if (defaultAttributes.includes(attrib.name)) {
-                        const prop = kebebCaseToCamelCase(attrib.name);
-                        this[prop] = attrib.value;
-                    }
-                };
+                // assign attributes to props
+                this.copyAttribsToProps(this.attributes);
 
                 const whereToBind = this.getAttribute("ref");
                 let listenTo = this.listenTo;
                 const pingIntervalS = this.pingIntervalS / 1;
-
                 if (listenTo) {
                     listenTo = typeof listenTo == "string" ? document.getElementById(listenTo) : listenTo;
                 }
@@ -124,7 +117,6 @@ All the changes from server are also received and propagated to your HTML.
                 } else {
                     this.isUsingOwnInstanceOfPalindrom = false;
                     // with already established connection we cannot change listenTo parameter
-
                     this.palindrom = palindrom;
                     palindrom.onLocalChange = this.onLocalChange.bind(this);
                     palindrom.onRemoteChange = this.onPatchApplied.bind(this);
@@ -163,11 +155,9 @@ All the changes from server are also received and propagated to your HTML.
             bindTo(element) {
                 // use node id or node itself;
                 element = typeof element == "string" ? document.getElementById(element) : element;
-
                 element.model = this.obj;
                 this.bound = element;
             }
-
             propagateDomBind(sequence) {
                 if (this.bound) {
                     this.notifyTemplateDomBind(this.bound.model, sequence, this.bound, "model");
@@ -176,16 +166,13 @@ All the changes from server are also received and propagated to your HTML.
                     this.notifyTemplateDomBind(this.obj, sequence, this, "obj");
                 }
             }
-
             onLocalChange(patches) {
                 // todo #26
                 this.propagateDomBind({ patches, results: patches.map(() => { }) });
             }
-
             fire(name, detail) {
                 this.dispatchEvent(new CustomEvent(name, { detail }));
             }
-
             onPatchReceived(data, url, method) {
                 this.fire("patchreceived", {
                     data,
@@ -193,7 +180,6 @@ All the changes from server are also received and propagated to your HTML.
                     method
                 });
             }
-
             onPatchSent(data, url, method) {
                 this.fire("patchsent", {
                     data,
@@ -201,7 +187,6 @@ All the changes from server are also received and propagated to your HTML.
                     method
                 });
             }
-
             onSocketStateChanged(state, url, data, statusCode, reason) {
                 this.fire("socketstatechanged", {
                     state,
@@ -211,7 +196,6 @@ All the changes from server are also received and propagated to your HTML.
                     reason
                 });
             }
-
             onConnectionError(palindromConnectionError) {
                 const eventDetail = {
                     error: palindromConnectionError,
@@ -225,36 +209,40 @@ All the changes from server are also received and propagated to your HTML.
                 };
                 this.fire("generic-error", eventDetail);
             }
-
             onReconnectionCountdown(milliseconds) {
                 const eventDetail = {
                     milliseconds,
                     handled: false
                 };
-
                 this.fire("reconnection-countdown", eventDetail);
             }
-
             onReconnectionEnd() {
                 const eventDetail = {
                     handled: false
                 };
                 this.fire("reconnection-end", eventDetail);
             }
-
             onPatchApplied(patches, results) {
                 this.propagateDomBind({ patches, results });
                 this.fire("patch-applied", {
                     patches
                 });
             }
-
             notifyTemplateDomBind(tree, patchesAndResults, templateDomBind, polymerPathPrefix) {
+                if (patchesAndResults.patches.length > this.mergedNotificationsThreshold) {
+                    console.warn(`palindrom-client has noticed a huge patch of ${patchesAndResults.patches.length} operations, for better performance palindrom-client will replace the whole palindrom object instead of applying your updates individually`);
+                    // clone to prevent flash of content
+                    templateDomBind.set('model', JSON.parse(JSON.stringify(this.obj)));
+                    // Polymer 2 is sync
+                    if (Polymer.Element) {
+                        templateDomBind.set('model', this.obj);
+                    } else { // Polymer 1 is async
+                        setTimeout(() => templateDomBind.set('model', this.obj));
+                    }
+                    return;
+                }
                 let operation;
                 let polymerPath;
-                const splices = {};
-                const notifications = {};
-
                 for (let operationNo = 0, len = patchesAndResults.patches.length; operationNo < len; operationNo++) {
                     operation = patchesAndResults.patches[operationNo];
                     const result = patchesAndResults.results[operationNo];
@@ -273,12 +261,7 @@ All the changes from server are also received and propagated to your HTML.
                         this.notifyTemplateDomBind(tree, newSequence, templateDomBind, polymerPathPrefix);
                         continue;
                     }
-
                     polymerPath = polymerPathPrefix + translateJSONPointerToPolymerPath(operation.path);
-
-                    /**
-                    *  STEP 1: COLLECT THE UPDATES, UNIQ THEM BY PATH
-                    * */
                     if (operation.op === 'test') {
                         // we assume that jsonpatch covered it already
                     } else if (operation.op === 'move' || operation.op === 'copy') {
@@ -288,44 +271,45 @@ All the changes from server are also received and propagated to your HTML.
                         const lastSeparator = operation.path.lastIndexOf('/');
                         let name = operation.path.substr(lastSeparator + 1);
                         const parentsPolymerPath = polymerPathPrefix + translateJSONPointerToPolymerPath(operation.path.substring(0, lastSeparator));
-
                         const parent = templateDomBind.get(parentsPolymerPath);
-
                         if (Array.isArray(parent) && (name === '-' || isNormalInteger(name))) {
-                            if (!splices[parentsPolymerPath]) {
-                                splices[parentsPolymerPath] = [];
-                            }
                             switch (operation.op) {
                                 case 'add':
                                     // JSONPatch push
                                     if (name === '-') {
                                         name = result.index;
                                     }
-                                    splices[parentsPolymerPath].push({
-                                        index: parseInt(name, 10),
-                                        removed: [],
-                                        addedCount: 1,
-                                        object: parent,
-                                        type: 'splice'
-                                    })
+                                    templateDomBind.notifySplices(parentsPolymerPath,
+                                        [{
+                                            index: parseInt(name, 10),
+                                            removed: [],
+                                            addedCount: 1,
+                                            object: parent,
+                                            type: 'splice'
+                                        }]
+                                    );
                                     break;
                                 case 'replace':
-                                    splices[parentsPolymerPath].push({
-                                        index: parseInt(name, 10),
-                                        removed: (result && [result.removed]) || [],
-                                        addedCount: 1,
-                                        object: parent,
-                                        type: 'splice'
-                                    });
+                                    templateDomBind.notifySplices(parentsPolymerPath,
+                                        [{
+                                            index: parseInt(name, 10),
+                                            removed: (result && [result.removed]) || [],
+                                            addedCount: 1,
+                                            object: parent,
+                                            type: 'splice'
+                                        }]
+                                    );
                                     break;
                                 case 'remove':
-                                    splices[parentsPolymerPath].push({
-                                        index: parseInt(name, 10),
-                                        removed: (result && [result.removed]) || [],
-                                        addedCount: 0,
-                                        object: parent,
-                                        type: 'splice'
-                                    });
+                                    templateDomBind.notifySplices(parentsPolymerPath,
+                                        [{
+                                            index: parseInt(name, 10),
+                                            removed: (result && [result.removed]) || [],
+                                            addedCount: 0,
+                                            object: parent,
+                                            type: 'splice'
+                                        }]
+                                    );
                                     break;
                             }
                         } else {
@@ -333,59 +317,33 @@ All the changes from server are also received and propagated to your HTML.
                                 case 'add':
                                 case 'replace':
                                     if (typeof operation.value === 'object') {
-                                        notifications[polymerPath] = [];
+                                        templateDomBind.notifyPath(polymerPath);
                                     } else {
-                                        notifications[polymerPath] = [operation.value, false];
+                                        templateDomBind.notifyPath(polymerPath, operation.value, false);
                                     }
                                     break;
                                 case 'remove':
-                                    notifications[polymerPath] = [null, false];
+                                    //console.warn('Polymer does not support unsetting properties https://github.com/Polymer/polymer/issues/2565');
+                                    //console.warn('remove is translated to JSON incompatible set to `undefined`, as there is no remove method in Polymer.')
+                                    templateDomBind.notifyPath(polymerPath, null, false);
+                                    templateDomBind.notifyPath(polymerPath, undefined, false);
                                     break;
                             }
                         }
                     }
                 }
-                /**
-                *  STEP 2: APPLY THE UPDATES
-                * */
-                const spliceEntries = Object.entries(splices);
-                const notificationEntries = Object.entries(notifications);
-                if (spliceEntries.length + notificationEntries.length > 100) {
-                    console.warn(`palindrom-client has noticed a huge patch of ${patchesAndResults.patches.length} operations, for better performance palindrom-client will replace the whole palindrom object instead of applying your updates individually`);
-                    // clone to prevent flash of content
-                    templateDomBind.set('model', JSON.parse(JSON.stringify(this.obj)));
-                    // Polymer 2 is sync
-                    if (Polymer.Element) {
-                        templateDomBind.set('model', this.obj);
-                    } else { // Polymer 1 is async
-                        setTimeout(() => templateDomBind.set('model', this.obj));
-                    }
-                } else {
-                    for (const [path, parameters] of spliceEntries) {
-                        templateDomBind.notifySplices(path, parameters);
-                    }
-                    for (const [path, parameters] of notificationEntries) {
-                        templateDomBind.notifyPath(path, ...parameters);
-                    }
-                }
             }
         }
-
         customElements.define('palindrom-client', PalindromClient);
-
         function translateJSONPointerToPolymerPath(pointer) {
             return pointer.replace(/\//g, '.');
         }
-
         function isNormalInteger(str) {
             const n = ~~Number(str);
             return String(n) === str && n >= 0;
         }
-
         function kebebCaseToCamelCase(str) {
             return str.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
         }
-
     })();
-
 </script>

--- a/palindrom-client.html
+++ b/palindrom-client.html
@@ -230,7 +230,7 @@ All the changes from server are also received and propagated to your HTML.
             }
             notifyTemplateDomBind(tree, patchesAndResults, templateDomBind, polymerPathPrefix) {
                 if (patchesAndResults.patches.length > this.mergedNotificationsThreshold) {
-                    console.warn(`palindrom-client has noticed a huge patch of ${patchesAndResults.patches.length} operations, for better performance palindrom-client will replace the whole palindrom object instead of applying your updates individually`);
+                    console.warn(`palindrom-client has noticed a huge patch of ${patchesAndResults.patches.length} operations. For better performance palindrom-client will replace the whole palindrom object instead of applying your updates individually`);
                     // clone to prevent flash of content
                     templateDomBind.set('model', JSON.parse(JSON.stringify(this.obj)));
                     // Polymer 2 is sync

--- a/palindrom-client.html
+++ b/palindrom-client.html
@@ -230,7 +230,7 @@ All the changes from server are also received and propagated to your HTML.
             }
             notifyTemplateDomBind(tree, patchesAndResults, templateDomBind, polymerPathPrefix) {
                 if (patchesAndResults.patches.length > this.mergedNotificationsThreshold) {
-                    console.warn(`palindrom-client has noticed a huge patch of ${patchesAndResults.patches.length} operations. For better performance palindrom-client will replace the whole palindrom object instead of applying your updates individually`);
+                    console.warn(`palindrom-client has noticed a huge patch of ${patchesAndResults.patches.length} operations. For better performance palindrom-client will replace the whole state object instead of applying your updates individually`);
                     // clone to prevent flash of content
                     templateDomBind.set('model', JSON.parse(JSON.stringify(this.obj)));
                     // Polymer 2 is sync

--- a/palindrom-client.html
+++ b/palindrom-client.html
@@ -29,6 +29,7 @@ All the changes from server are also received and propagated to your HTML.
             "fatalErrorReloadAfterS": 5,
             "mergedNotificationsThreshold": 100
         }
+        const defaultAttribs = ['merged-notifications-threshold', 'remote-url', 'use-web-socket', 'debug', 'local-version-path', 'remote-version-path', 'ot', 'purity', 'listen-to', 'ping-interval-s', 'purity', 'fatal-error-reload-after-s', 'path'];
         class PalindromClient extends HTMLElement {
             constructor() {
                 super();
@@ -36,7 +37,7 @@ All the changes from server are also received and propagated to your HTML.
                 Object.assign(this, defaultProps);
             }
             static get observedAttributes() {
-                return ['merged-notifications-threshold', 'remote-url', 'use-web-socket', 'debug', 'local-version-path', 'remote-version-path', 'ot', 'purity', 'listen-to', 'ping-interval-s', 'purity', 'fatal-error-reload-after-s', 'path'];
+                return ['merged-notifications-threshold'];
             }
             reconnectNow() {
                 this.palindrom.reconnectNow();
@@ -45,15 +46,8 @@ All the changes from server are also received and propagated to your HTML.
                 window.location.reload();
             }
             attributeChangedCallback(name, oldValue, value) {
-                this.copyAttribsToProps([{ name, value }]);
-            }
-            copyAttribsToProps(attribs) {
-                for (const attrib of attribs) {
-                    if (PalindromClient.observedAttributes.includes(attrib.name)) {
-                        const prop = kebebCaseToCamelCase(attrib.name);
-                        this[prop] = attrib.value;
-                    }
-                };
+                // it will only be called for merged-notifications-threshold attribute. See observedAttributes method
+                this.mergedNotificationsThreshold = value;
             }
             cancelReloading() {
                 clearInterval(this.reloadingInterval);
@@ -65,7 +59,12 @@ All the changes from server are also received and propagated to your HTML.
              */
             connectedCallback() {
                 // assign attributes to props
-                this.copyAttribsToProps(this.attributes);
+                for (const attrib of this.attributes) {
+                    if (defaultAttribs.includes(attrib.name)) {
+                        const prop = kebebCaseToCamelCase(attrib.name);
+                        this[prop] = attrib.value;
+                    }
+                }
 
                 const whereToBind = this.getAttribute("ref");
                 let listenTo = this.listenTo;


### PR DESCRIPTION
This PR collects all the needed updates in a map and then applies them all at once. This gives us room to apply heuristics and maybe make more decisions based on data size and nature to optimize applying updates.

The reason this needs to be done (as opposed to just doing `patch.length > 100 THEN replace-whole-obj`) is that updates depends on each other sometimes and their order is important. For instance, a `remove` and `replace` operations are not commutative and should have their order correct or an exception will be thrown and the rest of the patch will be ignored. That's why I *think* we need to update the updates individually when possible (N < 100). 

You might think updating the whole object doesn't break the order, that's right, but you cannot replace the object without resetting it to `undefined` first. You need 
```js
const model = domBind.model;
domBind.set('model', undefined)
domBind.set('model', model)
```

And since consecutive `set` calls cause issues in Polymer 1, you neet to call the third line asynchronously

```js
const model = domBind.model;
domBind.set('model', {})
setTimeout(() => domBind.set('model', model))
```

But it can happen that 
```js
const model = domBind.model;
domBind.set('model', {})
// Palindrom sends a new update here on an empty object, causing an exception 
setTimeout(() => domBind.set('model', model))
```

My fix does not eliminate this risk. But cuts the chance of it happening by folds. I don't think this exception will ever happen. In order for it to happen I *think* you need two consecutive huge patches at once. A very low probability.

Fixes #72 
